### PR TITLE
fix SHIKIMORI_URL

### DIFF
--- a/shikimori_api/shikimori_api.py
+++ b/shikimori_api/shikimori_api.py
@@ -6,7 +6,7 @@ from requests_oauthlib import OAuth2Session
 
 
 class Shikimori:
-    SHIKIMORI_URL: str = 'https://shikimori.one'
+    SHIKIMORI_URL: str = 'https://shikimori.me'
     _TOKEN_URL = SHIKIMORI_URL + '/oauth/token'
 
     def __init__(self,


### PR DESCRIPTION
Shikimori has changed domain to shikimori.me.
This is written about here: https://shikimori.me/forum/news/505429-novyy-domen-sayta-shikimori-me